### PR TITLE
compiling translation after installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,33 @@
 """Setup for recommender XBlock."""
 
 import os
+import subprocess
+from setuptools.command.install import install as _install
 from setuptools import setup
+
+
+class XBlockInstall(_install):
+    """Custom XBlock install command."""
+
+    def run(self):
+        _install.run(self)
+        self.compile_translations()
+
+    def compile_translations(self):
+        """
+        Compiles textual translations files(.po) to binary(.mo) files.
+        """
+        self.announce('Compiling translations')
+        try:
+            for dirname, _, files in os.walk(os.path.join('recommender', 'translations')):
+                for fname in files:
+                    if os.path.splitext(fname)[1] == '.po':
+                        po_path = os.path.join(dirname, fname)
+                        mo_path = os.path.splitext(po_path)[0] + '.mo'
+                        self.announce('Compiling translation at %s' % po_path)
+                        subprocess.check_call(['msgfmt', po_path, '-o', mo_path], cwd=self.install_lib)
+        except Exception as ex:
+            self.announce('Translations compilation failed: %s', ex.message)
 
 
 def package_data(pkg, root_list):
@@ -28,4 +54,7 @@ setup(
         ]
     },
     package_data=package_data("recommender", ["static", "translations"]),
+    cmdclass={
+        'install': XBlockInstall,
+    },
 )


### PR DESCRIPTION
@pmitros This PR has added post install hook to installation step which compiles translation. Downside of this approach is `pip uninstall` does not remove those compiled translation(.mo) when package is removed. I was not able to find a post uninstall hook either for setuptools or distutils.