### PR TITLE
Better error message when gettext is not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 """Setup for recommender XBlock."""
 import distutils.spawn
-from distutils import log
 import os
 import subprocess
+from distutils.errors import DistutilsSetupError
 from setuptools.command.install import install as _install
 from setuptools import setup
 
@@ -19,8 +19,7 @@ class XBlockInstall(_install):
         Compiles textual translations files(.po) to binary(.mo) files.
         """
         if distutils.spawn.find_executable("msgfmt") is None:
-            self.announce('msgfmt binary not found. Install gettext', log.ERROR)
-            raise RuntimeError
+            raise DistutilsSetupError('msgfmt binary not found. Install gettext')
         self.announce('Compiling translations')
         try:
             for dirname, _, files in os.walk(os.path.join('recommender', 'translations')):
@@ -31,8 +30,7 @@ class XBlockInstall(_install):
                         self.announce('Compiling translation at %s' % po_path)
                         subprocess.check_call(['msgfmt', po_path, '-o', mo_path], cwd=self.install_lib)
         except Exception as ex:
-            self.announce('Translations compilation failed: %s' % ex.message, log.ERROR)
-            raise
+            raise DistutilsSetupError('Translations compilation failed: %s' % ex.message)
 
 
 def package_data(pkg, root_list):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 """Setup for recommender XBlock."""
-
+import distutils.spawn
+import logging
 import os
 import subprocess
 from setuptools.command.install import install as _install
@@ -17,6 +18,9 @@ class XBlockInstall(_install):
         """
         Compiles textual translations files(.po) to binary(.mo) files.
         """
+        if distutils.spawn.find_executable("msgfmt") is None:
+            self.announce('msgfmt binary not found. Install gettext', logging.ERROR)
+            raise RuntimeError
         self.announce('Compiling translations')
         try:
             for dirname, _, files in os.walk(os.path.join('recommender', 'translations')):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ class XBlockInstall(_install):
                         self.announce('Compiling translation at %s' % po_path)
                         subprocess.check_call(['msgfmt', po_path, '-o', mo_path], cwd=self.install_lib)
         except Exception as ex:
-            self.announce('Translations compilation failed: %s', ex.message)
+            self.announce('Translations compilation failed: %s' % ex.message)
 
 
 def package_data(pkg, root_list):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """Setup for recommender XBlock."""
 import distutils.spawn
-import logging
+from distutils import log
 import os
 import subprocess
 from setuptools.command.install import install as _install
@@ -19,7 +19,7 @@ class XBlockInstall(_install):
         Compiles textual translations files(.po) to binary(.mo) files.
         """
         if distutils.spawn.find_executable("msgfmt") is None:
-            self.announce('msgfmt binary not found. Install gettext', logging.ERROR)
+            self.announce('msgfmt binary not found. Install gettext', log.ERROR)
             raise RuntimeError
         self.announce('Compiling translations')
         try:
@@ -31,7 +31,7 @@ class XBlockInstall(_install):
                         self.announce('Compiling translation at %s' % po_path)
                         subprocess.check_call(['msgfmt', po_path, '-o', mo_path], cwd=self.install_lib)
         except Exception as ex:
-            self.announce('Translations compilation failed: %s' % ex.message, logging.ERROR)
+            self.announce('Translations compilation failed: %s' % ex.message, log.ERROR)
             raise
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ class XBlockInstall(_install):
                         self.announce('Compiling translation at %s' % po_path)
                         subprocess.check_call(['msgfmt', po_path, '-o', mo_path], cwd=self.install_lib)
         except Exception as ex:
-            self.announce('Translations compilation failed: %s' % ex.message)
+            self.announce('Translations compilation failed: %s' % ex.message, logging.ERROR)
+            raise
 
 
 def package_data(pkg, root_list):


### PR DESCRIPTION
RecommenderXBlock currently requires the presence of the `msgfmt` binary to be installed.

If the binary is not present a very obscure message is printed.

This pull request improves that message to point out the solution of installing `gettext`.